### PR TITLE
README.md: add missing touch instruction for native build

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ cargo run \
     -Zbuild-std=core,alloc \
     -Zbuild-std-features=compiler-builtins-mem -- \
         --no-run
+touch .build-image
 ln -sf target/x86_64-custom/release/boot-bios-snakeos.img snakeos.img
 ```
 


### PR DESCRIPTION
Hi, very cool project! I've added a missing touch instruction to the instructions for building without docker. Otherwise they worked like a charm. I also had to increase the loop from 10000 to 1000000 (100 fold) to actually see the "welcome" message but probably the nicest fix for this is to implement a timer interrupt (didn't read enough of the code to see if that is already done).

Alon